### PR TITLE
Fix ticket creation date mapping

### DIFF
--- a/src/Form/TicketType.php
+++ b/src/Form/TicketType.php
@@ -24,12 +24,8 @@ class TicketType extends AbstractType
             ])
             ->add('status', ChoiceType::class, [
                 'choices' => Status::cases(),
-                'choice_label' => fn(Status $s) =>$s->name,
-                'choice_value' => fn(?Status $s) =>$s?->value,
-            ])
-
-            ->add('created_at', null, [
-                'widget' => 'single_text',
+                'choice_label' => fn(Status $s) => $s->name,
+                'choice_value' => fn(?Status $s) => $s?->value,
             ])
         ;
     }

--- a/templates/ticket/new.html.twig
+++ b/templates/ticket/new.html.twig
@@ -7,17 +7,18 @@
 
 {{ form_start(form, {attr: {class: 'row g-3'}}) }}
     <div class="col-12">
-        {{ form_row(form.title)}}
+        {{ form_row(form.title) }}
     </div>
     <div class="col-12">
-        {{ form_row(form.description)}}
+        {{ form_row(form.description) }}
     </div>
     <div class="col-12">
-        {{ form_row(form.priority)}}
+        {{ form_row(form.priority) }}
     </div>
     <div class="col-12">
-        {{ form_row(form.status)}}
+        {{ form_row(form.status) }}
     </div>
     <button type="submit" class="btn-form" arial-label="Bouton de validation">Je m'inscris</button>
     <a href="{{ path('app_ticket_index') }}">back to list</a>
+{{ form_end(form) }}
 {% endblock %}


### PR DESCRIPTION
## Summary
- fix TicketType to avoid overwriting `created_at`
- close ticket form properly

## Testing
- `composer install`
- `vendor/bin/phpunit --testdox` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6876b6eeff6083288da4a3860ed091fa